### PR TITLE
Only wake task up in case the swapped in set needs to be polled (fixes #5)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,13 +9,10 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: beta
+        toolchain: nightly
+        profile: minimal
         override: true
-    - name: cargo build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-    - name: cargo test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
+    - run: cargo build
+    - run: cargo test
+      env:
+        RUST_BACKTRACE: "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,22 +15,22 @@ keywords = ["async", "futures", "future"]
 categories = ["asynchronous", "algorithms"]
 
 [features]
-default = ["vec-safety"]
+default = ["futures-rs", "parking-lot"]
 parking-lot = ["lock_api", "parking_lot"]
-vec-safety = ["uniset/vec-safety"]
+futures-rs = ["futures-core"]
 
 [dependencies]
-futures-core = "0.3.4"
+futures-core = { version = "0.3.5", optional = true }
 parking_lot = { version = "0.10.2", optional = true }
 lock_api = { version = "0.3.4", optional = true }
-uniset = "0.1.1"
+uniset = { version = "0.2.0", features = ["vec-safety"] }
 
 [dev-dependencies]
 tokio = { version = "0.2.20", features = ["full"] }
 tokio-util = { version = "0.3.1", features = ["codec"] }
 checkers = "0.5.6"
 rand = "0.7.3"
-futures = "0.3.4"
+futures = "0.3.5"
 pin-utils = "0.1.0"
 hibitset = "0.6.3"
 criterion = "0.3.2"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ should consider putting it in production.
 ## Examples
 
 ```rust
-use tokio::{stream::StreamExt as _, time};
+use tokio::time;
 use std::time::Duration;
 use unicycle::FuturesUnordered;
 
@@ -60,7 +60,7 @@ async fn main() {
 [Unordered] types can be created from iterators:
 
 ```rust
-use tokio::{stream::StreamExt as _, time};
+use tokio::time;
 use std::time::Duration;
 use unicycle::FuturesUnordered;
 

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -4,6 +4,7 @@ mod internals {
     use std::sync::atomic::{AtomicIsize, Ordering};
 
     /// A simplified RwLock implementation which only supports voluntary locking.
+    #[repr(C)]
     pub struct RwLock {
         state: AtomicIsize,
     }

--- a/src/waker.rs
+++ b/src/waker.rs
@@ -105,6 +105,12 @@ impl SharedWaker {
     /// Swap out the current waker, dropping the one that was previously in
     /// place.
     ///
+    /// Returns `true` if the waker was successfully swapped, or swapping is not
+    /// necessary.
+    ///
+    /// Otherwise returns `false` and calling `wake_by_ref`, indicating that we
+    /// want to try again.
+    ///
     /// # Safety
     ///
     /// Caller must ensure that they are the only one who will attempt to lock

--- a/tests/spinning_futures_unordered_test.rs
+++ b/tests/spinning_futures_unordered_test.rs
@@ -41,7 +41,7 @@ async fn test_spinning_futures_unordered() {
     })
     .await;
 
-    // Note: FuturesUnordered will spin a bit before yielding.
+    // Note: FuturesUnordered has spun a bit before yielding.
     assert!(count.get() > 1);
 }
 
@@ -64,5 +64,5 @@ async fn test_spinning_unordered() {
     .await;
 
     // Note: Unicycle guarantees each future is poll at most once.
-    assert_eq!(1, count.get());
+    assert_eq!(2, count.get());
 }

--- a/tests/sporadic_timer_test.rs
+++ b/tests/sporadic_timer_test.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 use tokio::{stream::StreamExt as _, time};
 
 #[tokio::test(threaded_scheduler)]
-async fn test_bitset() {
+async fn test_unicycle_sporadic_timers() {
     use unicycle::FuturesUnordered;
 
     let mut futures = FuturesUnordered::new();
@@ -21,7 +21,7 @@ async fn test_bitset() {
 }
 
 #[tokio::test]
-async fn test_futures() {
+async fn test_futures_sporadic_timers() {
     use futures::stream::FuturesUnordered;
 
     let mut futures = FuturesUnordered::new();
@@ -37,24 +37,4 @@ async fn test_futures() {
     while let Some(_) = futures.next().await {}
 
     println!("futures: {:?}", Instant::now().duration_since(start));
-}
-
-#[tokio::test]
-async fn test_unicycle_streams() {
-    use tokio::stream::{iter, StreamExt as _};
-    use unicycle::StreamsUnordered;
-
-    let mut streams = StreamsUnordered::new();
-    assert!(streams.is_empty());
-
-    streams.push(iter(vec![1, 2, 3, 4]));
-    streams.push(iter(vec![5, 6, 7, 8]));
-
-    let mut received = Vec::new();
-
-    while let Some(value) = streams.next().await {
-        received.push(value);
-    }
-
-    assert_eq!(vec![1, 5, 2, 6, 3, 7, 4, 8], received);
 }

--- a/tests/stream_test.rs
+++ b/tests/stream_test.rs
@@ -1,0 +1,19 @@
+#[tokio::test]
+async fn test_unicycle_streams() {
+    use tokio::stream::iter;
+    use unicycle::StreamsUnordered;
+
+    let mut streams = StreamsUnordered::new();
+    assert!(streams.is_empty());
+
+    streams.push(iter(vec![1, 2, 3, 4]));
+    streams.push(iter(vec![5, 6, 7, 8]));
+
+    let mut received = Vec::new();
+
+    while let Some(value) = streams.next().await {
+        received.push(value);
+    }
+
+    assert_eq!(vec![5, 1, 6, 2, 7, 3, 8, 4], received);
+}


### PR DESCRIPTION
Passes tests and benchmarks.

Benchmarks for low number of tasks and/or threads improved quite a bit. Thanks for spotting the mistake @VShell!

![image](https://user-images.githubusercontent.com/111092/83668575-7997e600-a5d0-11ea-8ca8-26339bfafc6c.png)

![image](https://user-images.githubusercontent.com/111092/83668607-887e9880-a5d0-11ea-91d3-52d3b8d12a63.png)
