### PR TITLE
Fix trait bounds in Send/Sync impl: Unordered<T,S>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,8 +377,8 @@ where
     _marker: marker::PhantomData<S>,
 }
 
-unsafe impl<T, S> Send for Unordered<T, S> where S: Send + Sentinel {}
-unsafe impl<T, S> Sync for Unordered<T, S> where S: Sync + Sentinel {}
+unsafe impl<T: Send, S> Send for Unordered<T, S> where S: Sentinel {}
+unsafe impl<T: Sync, S> Sync for Unordered<T, S> where S: Sentinel {}
 
 impl<T, S> Unpin for Unordered<T, S> where S: Sentinel {}
 


### PR DESCRIPTION
This PR contains a follow-up fix for the issue raised in https://github.com/udoprog/unicycle/issues/8#issuecomment-763780334 .

Thank you for reviewing this PR :+1: 

p.s.
Would you also mind submitting a new release to crates.io that contains this fix?