### PR TITLE
Fix compile error in benches/unordered.rs

### DIFF
--- a/benches/unordered.rs
+++ b/benches/unordered.rs
@@ -56,7 +56,7 @@ pub fn polling_benchmark(c: &mut Criterion) {
             let txs = txs.clone();
 
             thread::spawn(move || {
-                while let Ok((n, tx)) = txs.pop() {
+                while let Some((n, tx)) = txs.pop() {
                     let _ = tx.send(n);
                 }
             });
@@ -102,7 +102,7 @@ pub fn polling_benchmark(c: &mut Criterion) {
             let txs = txs.clone();
 
             thread::spawn(move || {
-                while let Ok((n, tx)) = txs.pop() {
+                while let Some((n, tx)) = txs.pop() {
                     let _ = tx.send(n);
                 }
             });


### PR DESCRIPTION
The return type of `SegQueue::pop` changed from a `Result` to an `Option` somewhere between Crossbeam 0.7 and 0.8. Most of the code was updated already, but apparently not the benchmark.