### PR TITLE
Refactor Waker to make unsafe parts clearer and use less unsafe

### DIFF
--- a/src/waker.rs
+++ b/src/waker.rs
@@ -8,7 +8,7 @@
 use crate::{lock::RwLock, Shared};
 use std::{
     cell::UnsafeCell,
-    mem, ptr,
+    ptr,
     sync::Arc,
     task::{Context, RawWaker, RawWakerVTable, Waker},
 };
@@ -24,9 +24,8 @@ where
     // Need to assigned owned a fixed location, so do not move it from here for the duration of the poll.
     let internals = RefWaker { shared, index };
 
-    let waker = internals.as_raw_waker();
-    let waker = mem::ManuallyDrop::new(unsafe { Waker::from_raw(waker) });
-    let mut cx = Context::from_waker(&*waker);
+    let waker = unsafe { Waker::from_raw(internals.as_raw_waker()) };
+    let mut cx = Context::from_waker(&waker);
     f(&mut cx)
 }
 

--- a/src/waker.rs
+++ b/src/waker.rs
@@ -31,10 +31,10 @@ where
 }
 
 static INTERNALS_VTABLE: &RawWakerVTable = &RawWakerVTable::new(
-    Internals::unsafe_clone,
-    Internals::unsafe_wake,
-    Internals::unsafe_wake_by_ref,
-    Internals::unsafe_drop,
+    Internals::clone_unchecked,
+    Internals::wake_unchecked,
+    Internals::wake_by_ref_unchecked,
+    Internals::drop_unchecked,
 );
 
 struct Internals {
@@ -48,7 +48,7 @@ impl Internals {
         Self { shared, index }
     }
 
-    unsafe fn unsafe_clone(this: *const ()) -> RawWaker {
+    unsafe fn clone_unchecked(this: *const ()) -> RawWaker {
         // Safety: `this` is *const Self because it is called through the RawWaker vtable
         let this = &(*(this as *const Self));
         this.clone()
@@ -60,14 +60,14 @@ impl Internals {
         RawWaker::new(Box::into_raw(waker) as *const _, INTERNALS_VTABLE)
     }
 
-    unsafe fn unsafe_wake(this: *const ()) {
+    unsafe fn wake_unchecked(this: *const ()) {
         // Safety: `this` is *const Self because it is called through the RawWaker vtable
         // Note: this will never be called when it's passed by ref.
         let this = Box::from_raw(this as *mut Self);
         this.wake()
     }
 
-    unsafe fn unsafe_wake_by_ref(this: *const ()) {
+    unsafe fn wake_by_ref_unchecked(this: *const ()) {
         // Safety: `this` is *const Self because it is called through the RawWaker vtable
         let this = &(*(this as *const Self));
         this.wake()
@@ -80,7 +80,7 @@ impl Internals {
         shared.waker.wake_by_ref();
     }
 
-    unsafe fn unsafe_drop(this: *const ()) {
+    unsafe fn drop_unchecked(this: *const ()) {
         // Safety: `this` is *const Self because it is called through the RawWaker vtable
         Box::from_raw(this as *mut Self);
     }


### PR DESCRIPTION
The main change here is to make `Internals.shared` an `Arc<Shared>` instead of a `*const Shared`. This lets us avoid some unsafe casts and manually dropping.

It also splits the functions in the vtable into an unsafe wrapper that casts the `this` argument and then calls a safe function that does the actual work. This is to make it clearer which steps are actually unsafe and which are safe.