### PR TITLE
Share and reuse wakers

### DIFF
--- a/benches/unordered.rs
+++ b/benches/unordered.rs
@@ -12,9 +12,9 @@ pub fn polling_benchmark(c: &mut Criterion) {
             group.bench_with_input(BenchmarkId::new("unicycle", i), i, |b, i| {
                 b.iter(|| unicycle(*i, 1))
             });
-            group.bench_with_input(BenchmarkId::new("futures-rs", i), i, |b, i| {
-                b.iter(|| futures_rs(*i, 1))
-            });
+            // group.bench_with_input(BenchmarkId::new("futures-rs", i), i, |b, i| {
+            //     b.iter(|| futures_rs(*i, 1))
+            // });
         }
     }
 
@@ -25,9 +25,9 @@ pub fn polling_benchmark(c: &mut Criterion) {
             group.bench_with_input(BenchmarkId::new("unicycle", i), i, |b, i| {
                 b.iter(|| unicycle(10000, *i))
             });
-            group.bench_with_input(BenchmarkId::new("futures-rs", i), i, |b, i| {
-                b.iter(|| futures_rs(10000, *i))
-            });
+            // group.bench_with_input(BenchmarkId::new("futures-rs", i), i, |b, i| {
+            //     b.iter(|| futures_rs(10000, *i))
+            // });
         }
     }
 

--- a/benches/unordered.rs
+++ b/benches/unordered.rs
@@ -12,9 +12,9 @@ pub fn polling_benchmark(c: &mut Criterion) {
             group.bench_with_input(BenchmarkId::new("unicycle", i), i, |b, i| {
                 b.iter(|| unicycle(*i, 1))
             });
-            // group.bench_with_input(BenchmarkId::new("futures-rs", i), i, |b, i| {
-            //     b.iter(|| futures_rs(*i, 1))
-            // });
+            group.bench_with_input(BenchmarkId::new("futures-rs", i), i, |b, i| {
+                b.iter(|| futures_rs(*i, 1))
+            });
         }
     }
 
@@ -25,9 +25,9 @@ pub fn polling_benchmark(c: &mut Criterion) {
             group.bench_with_input(BenchmarkId::new("unicycle", i), i, |b, i| {
                 b.iter(|| unicycle(10000, *i))
             });
-            // group.bench_with_input(BenchmarkId::new("futures-rs", i), i, |b, i| {
-            //     b.iter(|| futures_rs(10000, *i))
-            // });
+            group.bench_with_input(BenchmarkId::new("futures-rs", i), i, |b, i| {
+                b.iter(|| futures_rs(10000, *i))
+            });
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,7 @@ use self::waker::SharedWaker;
 #[cfg(feature = "futures-rs")]
 use futures_core::{FusedStream, Stream};
 use parking_lot::RwLock;
+use pin_vec::PinVec;
 use std::{
     future::Future,
     iter, marker, mem,
@@ -172,6 +173,7 @@ use waker::{InternalWaker, InternalWakerRef};
 
 mod lock;
 pub mod pin_slab;
+mod pin_vec;
 mod wake_set;
 mod waker;
 
@@ -217,7 +219,7 @@ struct Shared {
     /// The currently registered wake set.
     wake_set: SharedWakeSet,
 
-    all_wakers: RwLock<Vec<InternalWaker>>,
+    all_wakers: RwLock<PinVec<InternalWaker>>,
 }
 
 impl Shared {
@@ -226,7 +228,7 @@ impl Shared {
         Self {
             waker: SharedWaker::new(),
             wake_set: SharedWakeSet::new(),
-            all_wakers: RwLock::new(Vec::new()),
+            all_wakers: RwLock::new(PinVec::new()),
         }
     }
 

--- a/src/pin_vec.rs
+++ b/src/pin_vec.rs
@@ -1,0 +1,84 @@
+use std::{
+    mem::{self, MaybeUninit},
+    ops::Index,
+};
+
+pub struct PinVec<T> {
+    // Slots of memory. Once one has been allocated it is never moved.
+    // This allows us to store entries in there and fetch them as `Pin<&mut T>`.
+    slots: Vec<Box<[MaybeUninit<T>]>>,
+    // Number of Filled elements currently in the slab
+    len: usize,
+}
+
+impl<T> PinVec<T> {
+    pub fn new() -> Self {
+        Self {
+            slots: Vec::new(),
+            len: 0,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn get(&self, index: usize) -> Option<&T> {
+        if index < self.len() {
+            let (slot, offset, _) = calculate_key(index);
+            // Safety: We guarantee that all indices <= self.len are initialized
+            unsafe { Some(self.slots[slot][offset].assume_init_ref()) }
+        } else {
+            None
+        }
+    }
+
+    pub fn push(&mut self, item: T) {
+        let (slot, offset, slot_len) = calculate_key(self.len);
+
+        if slot == self.slots.len() {
+            self.slots
+                .push((0..slot_len).map(|_| MaybeUninit::uninit()).collect());
+        }
+
+        self.slots[slot][offset].write(item);
+
+        self.len += 1;
+    }
+
+    pub fn extend(&mut self, items: impl Iterator<Item = T>) {
+        for item in items {
+            self.push(item)
+        }
+    }
+}
+
+impl<T> Index<usize> for PinVec<T> {
+    type Output = T;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        self.get(index).unwrap()
+    }
+}
+
+// Size of the first slot.
+const FIRST_SLOT_SIZE: usize = 16;
+// The initial number of bits to ignore for the first slot.
+const FIRST_SLOT_MASK: usize =
+    std::mem::size_of::<usize>() * 8 - FIRST_SLOT_SIZE.leading_zeros() as usize - 1;
+
+/// Calculate the key as a (slot, offset, len) tuple.
+const fn calculate_key(key: usize) -> (usize, usize, usize) {
+    assert!(key < (1usize << (mem::size_of::<usize>() * 8 - 1)));
+
+    let slot = ((mem::size_of::<usize>() * 8) as usize - key.leading_zeros() as usize)
+        .saturating_sub(FIRST_SLOT_MASK);
+
+    let (start, end) = if key < FIRST_SLOT_SIZE {
+        (0, FIRST_SLOT_SIZE)
+    } else {
+        (FIRST_SLOT_SIZE << (slot - 1), FIRST_SLOT_SIZE << slot)
+    };
+
+    (slot, key - start, end - start)
+}

--- a/src/waker.rs
+++ b/src/waker.rs
@@ -31,10 +31,10 @@ where
 }
 
 static INTERNALS_VTABLE: &RawWakerVTable = &RawWakerVTable::new(
-    Internals::unsafe_clone,
-    Internals::unsafe_wake,
-    Internals::unsafe_wake_by_ref,
-    Internals::unsafe_drop,
+    Internals::clone_unchecked,
+    Internals::wake_unchecked,
+    Internals::wake_by_ref_unchecked,
+    Internals::drop_unchecked,
 );
 
 struct Internals {
@@ -48,7 +48,7 @@ impl Internals {
         Self { shared, index }
     }
 
-    unsafe fn unsafe_clone(this: *const ()) -> RawWaker {
+    unsafe fn clone_unchecked(this: *const ()) -> RawWaker {
         // Safety: `this` is *const Self because it is called through the RawWaker vtable
         let this = &(*(this as *const Self));
         this.clone()
@@ -60,14 +60,14 @@ impl Internals {
         RawWaker::new(Box::into_raw(waker) as *const _, INTERNALS_VTABLE)
     }
 
-    unsafe fn unsafe_wake(this: *const ()) {
+    unsafe fn wake_unchecked(this: *const ()) {
         // Safety: `this` is *const Self because it is called through the RawWaker vtable
         // Note: this will never be called when it's passed by ref.
         let this = Box::from_raw(this as *mut Self);
         this.wake()
     }
 
-    unsafe fn unsafe_wake_by_ref(this: *const ()) {
+    unsafe fn wake_by_ref_unchecked(this: *const ()) {
         // Safety: `this` is *const Self because it is called through the RawWaker vtable
         let this = &(*(this as *const Self));
         this.wake()
@@ -80,7 +80,7 @@ impl Internals {
         shared.waker.wake_by_ref();
     }
 
-    unsafe fn unsafe_drop(this: *const ()) {
+    unsafe fn drop_unchecked(this: *const ()) {
         // Safety: `this` is *const Self because it is called through the RawWaker vtable
         Box::from_raw(this as *mut Self);
     }


### PR DESCRIPTION
This PR implements Option 2 from #14, and also builds upon #13.

It works by adding a list of `InternalWaker` objects to the `Shared` structure. Each of these internal wakers has a raw pointer to the `Shared` and a task index that it wakes. We don't use these objects as a waker directly, but instead wrap a pointer to them in `InternalWakerRef`. Creating an `InternalWakerRef` increments the ref count for the `Shared` state, and when the `InternalWakerRef` is dropped we decrement the `Shared` state ref count. This ensures that the `Shared` state will live as long as there are any references to a waker outstanding (see the `long_lived_waker` test in wakers.rs)

I added some tests to exercise tricky cases I could come up with and I made sure these pass running under Miri.

Benchmarks are a little mixed, but mostly good. See my results here: https://gist.github.com/eholk/f1ec4dd1a6376b1a046be6b058d93835 (I disabled the futures-rs variant to focus on comparing unicycle's current main branch with these changes)

Generally I saw small speed improvements from 3-7%. There were two significant slowdowns though. These were in the thread scaling tests once we got to 50 and 100 threads. I ran these tests on a 5950x with 32 logical cores, so it seems noteworthy that the slowdown started once the number of threads exceeded the number of cores. If this is true, maybe that regression is acceptable since most async code probably uses a thread-per-core model.

As far as what causes the slowdown at higher thread counts, I'm guessing it has to do with the `RwLock` I used in `InternalWakers`. I'm guessing there's another way we could do this, but I wanted to stick with something simple at first.

Anyway, I'd appreciate any feedback you have on this PR. Thanks!