### PR TITLE
Run destructors when clearing PinVec

### DIFF
--- a/src/pin_slab.rs
+++ b/src/pin_slab.rs
@@ -281,12 +281,6 @@ impl<T> Default for PinSlab<T> {
     }
 }
 
-impl<T> Drop for PinSlab<T> {
-    fn drop(&mut self) {
-        self.clear();
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::PinSlab;

--- a/src/pin_vec.rs
+++ b/src/pin_vec.rs
@@ -106,6 +106,8 @@ const fn calculate_key(key: usize) -> (usize, usize, usize) {
 mod tests {
     use crate::pin_vec::calculate_key;
 
+    use super::PinVec;
+
     #[test]
     fn key_test() {
         // NB: range of the first slot.
@@ -120,5 +122,25 @@ mod tests {
                 calculate_key((1usize << (i + 1)) - 1)
             );
         }
+    }
+
+    #[test]
+    fn run_destructors() {
+        let mut destructor_ran = false;
+
+        struct RunDestructor<'a>(&'a mut bool);
+        impl<'a> Drop for RunDestructor<'a> {
+            fn drop(&mut self) {
+                *self.0 = true;
+            }
+        }
+
+        {
+            // Make sure PinVec runs the destructors
+            let mut v = PinVec::new();
+            v.push(RunDestructor(&mut destructor_ran));
+        }
+
+        assert!(destructor_ran);
     }
 }

--- a/tests/pin_slab_memory_leak.rs
+++ b/tests/pin_slab_memory_leak.rs
@@ -1,0 +1,17 @@
+use unicycle::pin_slab::PinSlab;
+
+struct Foo(u32);
+
+struct Bar(Vec<u32>);
+
+#[global_allocator]
+static ALLOCATOR: checkers::Allocator = checkers::Allocator::system();
+
+#[checkers::test]
+fn test_pin_slab_memory_leak() {
+    let mut copy = PinSlab::new();
+    copy.insert(Foo(42));
+
+    let mut non_copy = PinSlab::new();
+    non_copy.insert(Bar(vec![42]));
+}


### PR DESCRIPTION
Also adds a `Drop` impl for `PinVec`, and removes the `Drop` impl for `PinSlab` since `PinSlab`'s `Drop` is redundant now.

Fixes #20, and also includes the test from #19.