### PR TITLE
Be more careful about pinning in `PinVec`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ futures-core = { version = "0.3.21", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
 lock_api = { version = "0.4.6", optional = true }
 uniset = { version = "0.2.0", features = ["vec-safety"] }
+pin-project = "1.0.10"
 
 [dev-dependencies]
 tokio = { version = "1.16.1", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,8 @@
 
 mod lock;
 pub mod pin_slab;
-mod pin_vec;
+#[doc(hidden)]
+pub mod pin_vec;
 mod wake_set;
 mod waker;
 


### PR DESCRIPTION
I realized `PinVec` had a `get_mut` method that was marked as safe even for `!Unpin` types. This means in safe code you code violate the pinning guarantees even in safe code, such as like this:
```rust
let mut item = Thing();
if let Some(pinned_item) = pinvec.get_mut(0) {
   mem::swap(pinned_item, &mut item);
}
```

This PR makes it so that `get_mut` is only applicable for `T: Unpin` and adds `get_unchecked_mut` and `get_pin_mut` methods that can be used instead. It also stores the data in a `PinVec` as a `Pin<Box<[T]>>` instead of a `Box<T>` to make it harder to make mistakes like this in the future.

I also added [pin_project](https://docs.rs/pin-project/latest/pin_project/index.html) as a dependency because it made some of the code cleaner.

This will probably conflict with #21, so I'd focus on merging that one first.

