### PR TITLE
Run Miri tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,28 @@ jobs:
         profile: minimal
         override: true
     - run: cargo build
+    - run: cargo test
+
+  miri:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        profile: minimal
+        components: miri
+        override: true
+    - run: cargo miri test -- pin_vec
+    - run: cargo miri test -- pin_slab
+
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+        components: rustfmt
+    - run: cargo fmt --check

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! ## Examples
 //!
-//! ```rust
+//! ```no_miri
 //! use tokio::time;
 //! use std::time::Duration;
 //! use unicycle::FuturesUnordered;
@@ -53,7 +53,7 @@
 //!
 //! [Unordered] types can be created from iterators:
 //!
-//! ```rust
+//! ```no_miri
 //! use tokio::time;
 //! use std::time::Duration;
 //! use unicycle::FuturesUnordered;
@@ -458,7 +458,7 @@ impl<T> FuturesUnordered<T> {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use unicycle::FuturesUnordered;
     ///
     /// let mut futures = FuturesUnordered::new();
@@ -569,7 +569,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::future::Ready;
     /// use unicycle::FuturesUnordered;
     ///
@@ -590,7 +590,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use unicycle::FuturesUnordered;
     ///
     /// let mut futures = FuturesUnordered::new();

--- a/src/pin_slab.rs
+++ b/src/pin_slab.rs
@@ -272,32 +272,3 @@ impl<T> Default for PinSlab<T> {
         Self::new()
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::PinSlab;
-
-    #[global_allocator]
-    static ALLOCATOR: checkers::Allocator = checkers::Allocator::system();
-
-    #[checkers::test]
-    fn insert_get_remove_many() {
-        let mut slab = PinSlab::new();
-
-        let mut keys = Vec::new();
-
-        for i in 0..1024 {
-            keys.push((i as u128, slab.insert(Box::new(i as u128))));
-        }
-
-        for (expected, key) in keys.iter().copied() {
-            let value = slab.get_pin_mut(key).expect("value to exist");
-            assert_eq!(expected, **value.as_ref());
-            assert!(slab.remove(key));
-        }
-
-        for (_, key) in keys.iter().copied() {
-            assert!(slab.get_pin_mut(key).is_none());
-        }
-    }
-}

--- a/tests/benchmark_test.rs
+++ b/tests/benchmark_test.rs
@@ -1,4 +1,5 @@
 #![cfg(features = "futures-rs")]
+#![cfg(not(miri))]
 
 use futures::channel::oneshot;
 use futures::future;

--- a/tests/pin_slab_insert_get_remove_many.rs
+++ b/tests/pin_slab_insert_get_remove_many.rs
@@ -1,0 +1,30 @@
+use unicycle::pin_slab::PinSlab;
+
+#[global_allocator]
+static ALLOCATOR: checkers::Allocator = checkers::Allocator::system();
+
+#[cfg(not(miri))]
+const AMOUNT: usize = 1024;
+#[cfg(miri)]
+const AMOUNT: usize = 128;
+
+#[checkers::test]
+fn pin_slab_insert_get_remove_many() {
+    let mut slab = PinSlab::new();
+
+    let mut keys = Vec::new();
+
+    for i in 0..AMOUNT {
+        keys.push((i as u128, slab.insert(Box::new(i as u128))));
+    }
+
+    for (expected, key) in keys.iter().copied() {
+        let value = slab.get_pin_mut(key).expect("value to exist");
+        assert_eq!(expected, **value.as_ref());
+        assert!(slab.remove(key));
+    }
+
+    for (_, key) in keys.iter().copied() {
+        assert!(slab.get_pin_mut(key).is_none());
+    }
+}

--- a/tests/spinning_futures_unordered_test.rs
+++ b/tests/spinning_futures_unordered_test.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "futures-rs")]
+#![cfg(not(miri))]
 
 use futures::future::poll_fn;
 use futures::stream::Stream;

--- a/tests/sporadic_timer_test.rs
+++ b/tests/sporadic_timer_test.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use std::time::{Duration, Instant};
 use tokio::time;
 use tokio_stream::StreamExt;


### PR DESCRIPTION
Sets up running miri on `pin_vec` and `pin_slab` tests. Anything involving `#[tokio::main]` does not run, since it requires the use of native system calls which is not supported.

Also expands `build` profile to run tests.