### PR TITLE
Remove unnecessary wake_by_ref

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -541,7 +541,6 @@ where
             if let Poll::Ready(result) = result {
                 let removed = slab.remove(index);
                 debug_assert!(removed);
-                cx.waker().wake_by_ref();
                 return Poll::Ready(Some(result));
             }
         }


### PR DESCRIPTION
This was originally there because multiple sub-futures could be woken at the same time and we'd want to make sure they each get polled and drained. It turns out this is unnecessary.

The reason is that this gives a stream-like abstraction, so it is up to the caller to decide whether to drive the future to yield the next item by calling `poll_next`. This call to `poll_next` will then poll any ready futures.

If the caller does not poll anything, then the futures will be cleaned up correctly when the container is dropped.