### PR TITLE
Deallocate separately from reference counting

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -147,7 +147,11 @@ impl<T> Storage<T> {
         // before dropping the storage of the slab.
         unsafe {
             for &entry in &self.entries {
-                Header::decrement_ref(entry.cast());
+                if entry.as_ref().header.decrement_ref() {
+                    // SAFETY: We're the only ones holding a reference to the
+                    // entry, so it's safe to drop it.
+                    _ = Box::from_raw(entry.as_ptr());
+                }
             }
 
             self.entries.set_len(0);


### PR DESCRIPTION
Storage doesn't need to use vtable for deallocating the entry.

Also implements the MAX_REFCOUNT soft limit like `std::sync::Arc<T>`.