### PR TITLE
Add function for removal futures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,7 +439,7 @@ where
             let result = self::waker::poll_with_ref(header, move |cx| fut.poll(cx));
 
             if let Poll::Ready(result) = result {
-                let removed = slab.remove(index);
+                let removed = slab.remove(index).is_some();
                 debug_assert!(removed);
                 return Poll::Ready(Some(result));
             }
@@ -556,6 +556,41 @@ where
         }
 
         index
+    }
+
+    /// Remove the future or stream at the given index and return it.
+    ///
+    /// Returns `Some(T)` if the index was valid and contained a value,
+    /// `None` if the index is out of bounds or the slot is vacant.
+    ///
+    /// # Safety
+    /// Returned future must be either `T: Unpin` or be complete and no longer polled.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use unicycle::FuturesUnordered;
+    ///
+    /// let mut futures = FuturesUnordered::new();
+    /// let index = futures.push(Box::pin(async { 42 }));
+    ///
+    /// let removed = futures.remove(index);
+    /// assert!(removed.is_some());
+    /// assert!(futures.is_empty());
+    /// ```
+    pub fn remove(&mut self, index: usize) -> Option<T>
+    where
+        T: Unpin,
+    {
+        self.slab.remove(index)
+    }
+
+    /// See [Unordered::remove] for details. This function differ that it allows removing `T: !Unpin` as well.
+    ///
+    /// # Safety
+    /// Returned future must complete and never polled.
+    pub unsafe fn remove_unchecked(&mut self, index: usize) -> Option<T> {
+        self.slab.remove(index)
     }
 
     /// Get a pinned mutable reference to the stream or future at the given
@@ -919,7 +954,7 @@ cfg_futures_rs! {
                             return Poll::Ready(Some(value));
                         }
                         None => {
-                            let removed = slab.remove(index);
+                            let removed = slab.remove(index).is_some();
                             debug_assert!(removed);
                         }
                     }
@@ -989,7 +1024,7 @@ cfg_futures_rs! {
                         }
                         None => {
                             cx.waker().wake_by_ref();
-                            let removed = slab.remove(index);
+                            let removed = slab.remove(index).is_some();
                             debug_assert!(removed);
                             return Poll::Ready(Some((index, None)));
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,7 +439,7 @@ where
             let result = self::waker::poll_with_ref(header, move |cx| fut.poll(cx));
 
             if let Poll::Ready(result) = result {
-                let removed = slab.remove(index).is_some();
+                let removed = slab.remove_in_place(index);
                 debug_assert!(removed);
                 return Poll::Ready(Some(result));
             }
@@ -563,9 +563,6 @@ where
     /// Returns `Some(T)` if the index was valid and contained a value,
     /// `None` if the index is out of bounds or the slot is vacant.
     ///
-    /// # Safety
-    /// Returned future must be either `T: Unpin` or be complete and no longer polled.
-    ///
     /// # Examples
     ///
     /// ```
@@ -585,12 +582,10 @@ where
         self.slab.remove(index)
     }
 
-    /// See [Unordered::remove] for details. This function differ that it allows removing `T: !Unpin` as well.
-    ///
-    /// # Safety
-    /// Returned future must complete and never polled.
-    pub unsafe fn remove_unchecked(&mut self, index: usize) -> Option<T> {
-        self.slab.remove(index)
+    /// See [Unordered::remove] for details. This function differ that
+    /// it also allows removing `T: !Unpin` futures without returning them.
+    pub fn remove_in_place(&mut self, index: usize) -> bool {
+        self.slab.remove_in_place(index)
     }
 
     /// Get a pinned mutable reference to the stream or future at the given
@@ -954,7 +949,7 @@ cfg_futures_rs! {
                             return Poll::Ready(Some(value));
                         }
                         None => {
-                            let removed = slab.remove(index).is_some();
+                            let removed = slab.remove_in_place(index);
                             debug_assert!(removed);
                         }
                     }
@@ -1024,7 +1019,7 @@ cfg_futures_rs! {
                         }
                         None => {
                             cx.waker().wake_by_ref();
-                            let removed = slab.remove(index).is_some();
+                            let removed = slab.remove_in_place(index);
                             debug_assert!(removed);
                             return Poll::Ready(Some((index, None)));
                         }

--- a/src/task.rs
+++ b/src/task.rs
@@ -320,20 +320,20 @@ mod tests {
     fn test_basic() {
         let mut slab = Storage::new();
 
-        assert!(!slab.remove(0).is_some());
+        assert!(slab.remove(0).is_none());
         let index = slab.insert(42);
         assert!(slab.remove(index).is_some());
-        assert!(!slab.remove(index).is_some());
+        assert!(slab.remove(index).is_none());
     }
 
     #[test]
     fn test_new() {
         let mut slab = Storage::new();
 
-        assert!(!slab.remove(0).is_some());
+        assert!(slab.remove(0).is_none());
         let index = slab.insert(42);
         assert!(slab.remove(index).is_some());
-        assert!(!slab.remove(index).is_some());
+        assert!(slab.remove(index).is_none());
     }
 
     #[test]
@@ -371,10 +371,10 @@ mod tests {
     fn test_remove() {
         let mut slab = Storage::new();
 
-        assert!(!slab.remove(0).is_some());
+        assert!(slab.remove(0).is_none());
         let index = slab.insert(42);
         assert!(slab.remove(index).is_some());
-        assert!(!slab.remove(index).is_some());
+        assert!(slab.remove(index).is_none());
     }
 
     #[test]

--- a/src/task.rs
+++ b/src/task.rs
@@ -188,26 +188,21 @@ impl<T> Storage<T> {
 
     /// Remove the key from the slab.
     ///
-    /// Returns `true` if the entry was removed, `false` otherwise.
-    /// Removing a key which does not exist has no effect, and `false` will be
+    /// Returns `Some(value)` if the entry was removed, `None` otherwise.
+    /// Removing a key which does not exist has no effect, and `None` will be
     /// returned.
     ///
     /// We need to take care that we don't move it, hence we only perform
     /// operations over pointers below.
-    pub(crate) fn remove(&mut self, key: usize) -> bool {
-        let task = match self.tasks.get(key) {
-            Some(entry) => *entry,
-            None => return false,
-        };
+    pub(crate) fn remove(&mut self, key: usize) -> Option<T> {
+        let task = *self.tasks.get(key)?;
 
         // SAFETY: The `task` pointer is valid, since we got it from the slab.
-        if !unsafe { make_slot_vacant(task, self.next) } {
-            return false;
-        }
+        let value = unsafe { take_slot(task, self.next) }?;
 
         self.len -= 1;
         self.next = key;
-        true
+        Some(value)
     }
 
     /// Clear all available data in the PinSlot.
@@ -221,7 +216,7 @@ impl<T> Storage<T> {
                 //
                 // Also, we violate the linked list of vacant slots by passing `0` here
                 // because the whole `tasks` vector will be cleared below anyway.
-                make_slot_vacant(task, 0);
+                take_slot(task, 0);
 
                 if task.as_ref().header.decrement_ref() {
                     // SAFETY: We're the only ones holding a reference to the
@@ -264,22 +259,26 @@ impl<T> Storage<T> {
     }
 }
 
-/// Returns `true` if the entry was removed, `false` otherwise.
+/// Takes the value from the slot and makes it vacant.
+/// Returns `Some(value)` if the entry contained a value, `None` otherwise.
 ///
 /// # Safety
 /// * The `task` pointer must point to a valid entry.
 /// * A task's entry must be accessed only by one thread.
-unsafe fn make_slot_vacant<T>(task: NonNull<Task<T>>, next: usize) -> bool {
+unsafe fn take_slot<T>(task: NonNull<Task<T>>, next: usize) -> Option<T> {
     // SAFETY: We have mutable access to the given entry, but we are careful
     // not to dereference the header mutably, since that might be shared.
     let entry = unsafe { &mut *ptr::addr_of_mut!((*task.as_ptr()).entry) };
 
-    if !matches!(entry, Entry::Some(_)) {
-        return false;
+    match entry {
+        Entry::Some(_) => {
+            let Entry::Some(value) = std::mem::replace(entry, Entry::Vacant(next)) else {
+                unreachable!()
+            };
+            Some(value)
+        }
+        _ => None,
     }
-
-    *entry = Entry::Vacant(next);
-    true
 }
 
 impl<T> Default for Storage<T> {
@@ -321,20 +320,20 @@ mod tests {
     fn test_basic() {
         let mut slab = Storage::new();
 
-        assert!(!slab.remove(0));
+        assert!(!slab.remove(0).is_some());
         let index = slab.insert(42);
-        assert!(slab.remove(index));
-        assert!(!slab.remove(index));
+        assert!(slab.remove(index).is_some());
+        assert!(!slab.remove(index).is_some());
     }
 
     #[test]
     fn test_new() {
         let mut slab = Storage::new();
 
-        assert!(!slab.remove(0));
+        assert!(!slab.remove(0).is_some());
         let index = slab.insert(42);
-        assert!(slab.remove(index));
-        assert!(!slab.remove(index));
+        assert!(slab.remove(index).is_some());
+        assert!(!slab.remove(index).is_some());
     }
 
     #[test]
@@ -372,10 +371,10 @@ mod tests {
     fn test_remove() {
         let mut slab = Storage::new();
 
-        assert!(!slab.remove(0));
+        assert!(!slab.remove(0).is_some());
         let index = slab.insert(42);
-        assert!(slab.remove(index));
-        assert!(!slab.remove(index));
+        assert!(slab.remove(index).is_some());
+        assert!(!slab.remove(index).is_some());
     }
 
     #[test]

--- a/src/task.rs
+++ b/src/task.rs
@@ -194,7 +194,10 @@ impl<T> Storage<T> {
     ///
     /// We need to take care that we don't move it, hence we only perform
     /// operations over pointers below.
-    pub(crate) fn remove(&mut self, key: usize) -> Option<T> {
+    pub(crate) fn remove(&mut self, key: usize) -> Option<T>
+    where
+        T: Unpin,
+    {
         let task = *self.tasks.get(key)?;
 
         // SAFETY: The `task` pointer is valid, since we got it from the slab.
@@ -203,6 +206,30 @@ impl<T> Storage<T> {
         self.len -= 1;
         self.next = key;
         Some(value)
+    }
+
+    /// Remove the key from the slab.
+    ///
+    /// Returns `true` if the entry was removed, `false` otherwise.
+    /// Removing a key which does not exist has no effect, and `false` will be
+    /// returned.
+    ///
+    /// We need to take care that we don't move it, hence we only perform
+    /// operations over pointers below.
+    pub(crate) fn remove_in_place(&mut self, key: usize) -> bool {
+        let task = match self.tasks.get(key) {
+            Some(entry) => *entry,
+            None => return false,
+        };
+
+        // SAFETY: The `task` pointer is valid, since we got it from the slab.
+        if !unsafe { make_slot_vacant(task, self.next) } {
+            return false;
+        }
+
+        self.len -= 1;
+        self.next = key;
+        true
     }
 
     /// Clear all available data in the PinSlot.
@@ -216,7 +243,7 @@ impl<T> Storage<T> {
                 //
                 // Also, we violate the linked list of vacant slots by passing `0` here
                 // because the whole `tasks` vector will be cleared below anyway.
-                take_slot(task, 0);
+                make_slot_vacant(task, 0);
 
                 if task.as_ref().header.decrement_ref() {
                     // SAFETY: We're the only ones holding a reference to the
@@ -281,6 +308,24 @@ unsafe fn take_slot<T>(task: NonNull<Task<T>>, next: usize) -> Option<T> {
     }
 }
 
+/// Returns `true` if the entry was removed, `false` otherwise.
+///
+/// # Safety
+/// * The `task` pointer must point to a valid entry.
+/// * A task's entry must be accessed only by one thread.
+unsafe fn make_slot_vacant<T>(task: NonNull<Task<T>>, next: usize) -> bool {
+    // SAFETY: We have mutable access to the given entry, but we are careful
+    // not to dereference the header mutably, since that might be shared.
+    let entry = unsafe { &mut *ptr::addr_of_mut!((*task.as_ptr()).entry) };
+
+    if !matches!(entry, Entry::Some(_)) {
+        return false;
+    }
+
+    *entry = Entry::Vacant(next);
+    true
+}
+
 impl<T> Default for Storage<T> {
     fn default() -> Self {
         Self::new()
@@ -320,20 +365,20 @@ mod tests {
     fn test_basic() {
         let mut slab = Storage::new();
 
-        assert!(slab.remove(0).is_none());
+        assert!(!slab.remove_in_place(0));
         let index = slab.insert(42);
-        assert!(slab.remove(index).is_some());
-        assert!(slab.remove(index).is_none());
+        assert!(slab.remove_in_place(index));
+        assert!(!slab.remove_in_place(index));
     }
 
     #[test]
     fn test_new() {
         let mut slab = Storage::new();
 
-        assert!(slab.remove(0).is_none());
+        assert!(!slab.remove_in_place(0));
         let index = slab.insert(42);
-        assert!(slab.remove(index).is_some());
-        assert!(slab.remove(index).is_none());
+        assert!(slab.remove_in_place(index));
+        assert!(!slab.remove_in_place(index));
     }
 
     #[test]
@@ -371,10 +416,10 @@ mod tests {
     fn test_remove() {
         let mut slab = Storage::new();
 
-        assert!(slab.remove(0).is_none());
+        assert!(!slab.remove_in_place(0));
         let index = slab.insert(42);
-        assert!(slab.remove(index).is_some());
-        assert!(slab.remove(index).is_none());
+        assert!(slab.remove_in_place(index));
+        assert!(!slab.remove_in_place(index));
     }
 
     #[test]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,2 +1,3 @@
 mod pin_slab_insert_get_remove_many;
 mod pin_slab_memory_leak;
+mod unordered_remove;

--- a/src/tests/pin_slab_insert_get_remove_many.rs
+++ b/src/tests/pin_slab_insert_get_remove_many.rs
@@ -18,7 +18,7 @@ fn pin_slab_insert_get_remove_many() {
     for (expected, key) in keys.iter().copied() {
         let (_, value) = slab.get_pin_mut(key).expect("value to exist");
         assert_eq!(expected, **value.as_ref());
-        assert!(slab.remove(key));
+        assert!(slab.remove(key).is_some());
     }
 
     for (_, key) in keys.iter().copied() {

--- a/src/tests/unordered_remove.rs
+++ b/src/tests/unordered_remove.rs
@@ -1,7 +1,6 @@
 use std::future::ready;
 
 use futures::FutureExt;
-use tokio_stream::StreamExt;
 
 use crate::FuturesUnordered;
 
@@ -32,7 +31,10 @@ async fn test_complete_unpinned() {
 
     let fut = futures.remove(idx).unwrap();
 
-    let mut res = futures.collect::<Vec<_>>().await;
+    let mut res = vec![];
+    while let Some(x) = futures.next().await {
+        res.push(x);
+    }
     res.sort();
     assert_eq!(res, vec![1, 2, 4]);
     assert_eq!(fut.await, 3);

--- a/src/tests/unordered_remove.rs
+++ b/src/tests/unordered_remove.rs
@@ -1,0 +1,56 @@
+use std::future::ready;
+
+use futures::FutureExt;
+use tokio_stream::StreamExt;
+
+use crate::FuturesUnordered;
+
+#[test]
+fn test_remove() {
+    let mut futures = FuturesUnordered::new();
+    let index = futures.push(ready(42));
+
+    assert_eq!(futures.len(), 1);
+
+    let removed = futures.remove(index);
+    assert!(removed.is_some());
+    assert_eq!(futures.len(), 0);
+
+    assert!(futures.remove(index).is_none());
+    assert!(futures.remove(0).is_none());
+    assert!(futures.remove(999).is_none());
+}
+
+#[tokio::test]
+async fn test_complete_unpinned() {
+    let mut futures = FuturesUnordered::new();
+
+    futures.push(Box::pin(ready(1)));
+    futures.push(Box::pin(ready(2)));
+    let idx = futures.push(Box::pin(ready(3)));
+    futures.push(Box::pin(ready(4)));
+
+    let fut = futures.remove(idx).unwrap();
+
+    let mut res = futures.collect::<Vec<_>>().await;
+    res.sort();
+    assert_eq!(res, vec![1, 2, 4]);
+    assert_eq!(fut.await, 3);
+}
+
+#[tokio::test]
+async fn test_manual_poll_then_remove() {
+    let mut futures = FuturesUnordered::new();
+
+    let fut = std::future::ready(123);
+    let idx = futures.push(fut);
+
+    let res = futures.get_pin_mut(idx).unwrap().now_or_never();
+    assert!(res.is_some());
+
+    let _fut = futures.remove(idx).unwrap();
+
+    let res = futures.next().now_or_never();
+    assert_eq!(res, Some(None));
+    assert!(futures.is_empty());
+}


### PR DESCRIPTION
It seems with a current API only `T: Unpin` could be removed safely, so there are two functions remove and remove_unchecked. Not sure about the safety comment for the last one (perhaps too strict?).

Resolves https://github.com/udoprog/unicycle/issues/26